### PR TITLE
[BUGFIX] Add missing allowed class for OAuth request unserilization

### DIFF
--- a/Classes/Middleware/OAuth2Authorization.php
+++ b/Classes/Middleware/OAuth2Authorization.php
@@ -95,7 +95,13 @@ final class OAuth2Authorization implements MiddlewareInterface, LoggerAwareInter
         // With TYPO3 11.5.17 it takes 3 loops to unserialize the AuthorizationRequest
         $count = 0;
         while (!$authorizationRequest instanceof AuthorizationRequest && $count < 10) {
-            $authorizationRequest = unserialize($authorizationRequest, ['allowed_classes' => ['League\OAuth2\Server\RequestTypes\AuthorizationRequest', 'FGTCLB\OAuth2Server\Domain\Entity\Client']]);
+            $authorizationRequest = unserialize($authorizationRequest, [
+                'allowed_classes' => [
+                    'League\OAuth2\Server\RequestTypes\AuthorizationRequest',
+                    'FGTCLB\OAuth2Server\Domain\Entity\Client',
+                    'FGTCLB\OAuth2Server\Domain\Entity\Scope',
+                ],
+            ]);
             $count++;
         }
 


### PR DESCRIPTION
Restricting allowed classes when unserializing strings
into a classe structure is a security restricting to
mitigate exploiting abitary classes. Not listed classes
will be deserialized as an incomplete PHP class, ending
into an TypeError when passed to a method with strict
native type declaration.

This change adds the required custom scrope class to
the allowed list when trying to unserialize the oauth
request. That mitigates the TypeError now when doing
a successfull login.
