### PR TITLE
[TASK] Streamline identity handler implementation

### DIFF
--- a/Classes/DependencyInjection/IdentityHandlerPass.php
+++ b/Classes/DependencyInjection/IdentityHandlerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class IdentityHandlerPass implements CompilerPassInterface
+final class IdentityHandlerPass implements CompilerPassInterface
 {
     /**
      * @inheritDoc
@@ -19,11 +19,8 @@ class IdentityHandlerPass implements CompilerPassInterface
         if (!$container->has(IdentityHandlingFactory::class)) {
             return;
         }
-
         $definition = $container->findDefinition(IdentityHandlingFactory::class);
-
         $taqgedServices = $container->findTaggedServiceIds('oauth.identity_handler');
-
         foreach ($taqgedServices as $id => $tags) {
             foreach ($tags as $attributes) {
                 $definition->addMethodCall(

--- a/Classes/Service/AbstractIdentityHandler.php
+++ b/Classes/Service/AbstractIdentityHandler.php
@@ -8,14 +8,22 @@ use FGTCLB\OAuth2Server\Configuration;
 
 abstract class AbstractIdentityHandler implements IdentityHandlerInterface
 {
-    protected string $clientId = '';
     /**
      * @var string[]
      */
     protected array $scopes = [];
-    protected Configuration $configuration;
 
-    public function __construct(Configuration $configuration)
+    protected ?Configuration $configuration = null;
+
+    /**
+     * Ensure that configuration can be passed and made available
+     * in all handler implementation as enforcing constructor in
+     * interfaces are discouraged. Same counts eventually provided
+     * abstract implementations to leave constructor conflict free.
+     *
+     * {@see IdentityHandlingFactory::addIdentityHandler()}
+     */
+    public function setConfiguration(Configuration $configuration): void
     {
         $this->configuration = $configuration;
     }

--- a/Classes/Service/DefaultIdentityHandler.php
+++ b/Classes/Service/DefaultIdentityHandler.php
@@ -8,12 +8,25 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
-class DefaultIdentityHandler extends AbstractIdentityHandler
+final class DefaultIdentityHandler extends AbstractIdentityHandler
 {
+    private string $clientId = '';
+
+    public function setClientId(string $clientId): self
+    {
+        $this->clientId = $clientId;
+        return $this;
+    }
+
     public function handleAuthenticatedRequest(ServerRequestInterface $request): ResponseInterface
     {
         return new JsonResponse(
-            ['error' => 'Client ID has no implemented Handler in OAuth Response server'],
+            [
+                'error' => sprintf(
+                    'Client ID "%s" has no implemented Handler in OAuth Response server',
+                    $this->clientId
+                ),
+            ],
             501
         );
     }

--- a/Classes/Service/IdentityHandlerInterface.php
+++ b/Classes/Service/IdentityHandlerInterface.php
@@ -4,10 +4,25 @@ declare(strict_types=1);
 
 namespace FGTCLB\OAuth2Server\Service;
 
+use FGTCLB\OAuth2Server\Configuration;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 interface IdentityHandlerInterface
 {
+    /**
+     * Ensure that configuration can be passed and made available
+     * in all handler implementation as enforcing constructor in
+     * interfaces are discouraged. Same counts eventually provided
+     * abstract implementations to leave constructor conflict free.
+     *
+     * {@see IdentityHandlingFactory::addIdentityHandler()}
+     */
+    public function setConfiguration(Configuration $configuration): void;
+
+    /**
+     * Handles the identity request. Only called if route path matches `/oauth2/identity`
+     * and client id matches the value used for registering the implemented handler.
+     */
     public function handleAuthenticatedRequest(ServerRequestInterface $request): ResponseInterface;
 }

--- a/Classes/Service/IdentityHandlingFactory.php
+++ b/Classes/Service/IdentityHandlingFactory.php
@@ -4,27 +4,37 @@ declare(strict_types=1);
 
 namespace FGTCLB\OAuth2Server\Service;
 
-class IdentityHandlingFactory
+use FGTCLB\OAuth2Server\Configuration;
+
+final class IdentityHandlingFactory
 {
     /**
      * @var IdentityHandlerInterface[]
      */
     private array $handlers = [];
 
-    public function __construct(DefaultIdentityHandler $defaultIdentityHandler)
-    {
-        $this->handlers['_default'] = $defaultIdentityHandler;
+    private Configuration $configuration;
+    private DefaultIdentityHandler $defaultIdentityHandler;
+
+    public function __construct(
+        DefaultIdentityHandler $defaultIdentityHandler,
+        Configuration $configuration
+    ) {
+        $defaultIdentityHandler->setConfiguration($configuration);
+        $this->configuration = $configuration;
+        $this->defaultIdentityHandler = $defaultIdentityHandler;
     }
 
     public function addIdentityHandler(
         IdentityHandlerInterface $resourceHandler,
         string $clientId
     ): void {
+        $resourceHandler->setConfiguration($this->configuration);
         $this->handlers[$clientId] = $resourceHandler;
     }
 
     public function getIdentityHandler(string $clientId): IdentityHandlerInterface
     {
-        return $this->handlers[$clientId] ?? $this->handlers['_default'];
+        return $this->handlers[$clientId] ?? $this->defaultIdentityHandler->setClientId($clientId);
     }
 }


### PR DESCRIPTION
This extension ships a generic middleware implementation
dispatching to registered custom handler implementations
based on the `IdentityHandlerInterface`, providing base
functionality with the `AbstractIdentityHandler`.

It's considerable bad practice to pullate constructor in
abstract classes to avoid making the constructor public
api and falling under casual breaking policy, which has
been ignored with the first implementation towards the
2.x implementation. Not having a release in place, this
is now corrected.

* Add `setConfiguration(Configuration $configuration)`
  to the interface, set by the `IdentityHandlingFactory`,
  ensures that all handler implementation recives the
  OAuth2 server configuration.
* `AbstractIdenttyHandler::__construct()` is replaced
  by implementing the new `IdentityHandlerInterface`
  method `setConfiguration()`.
* `DefaultIdentityHandler` is used as error default and
  is now marked final, got a setter to set the client
  id and is not registered normally in the stack and
  used as default for not registered clientId responding
  with the client id in the error message to easy the
  debugging.
* `IdentityHandlerFactory` is modified to recieve the
  OAuth configuration and set it to all handlers which
  are registered using the new interface setter.
